### PR TITLE
v6 updates and better controls

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# use spaces by default for everything
+[*.{cs,vb}]
+indent_style = space
+indent_size = 4
+tab_size = 4
+charset=utf-8-bom
+spaces_around_brackets = none
+
+[*]
+indent_style = space
+indent_size = 2
+tab_size = 2

--- a/Helpers.cs
+++ b/Helpers.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Diagnostics;
 using System.Xml;
-namespace MonoDevelop.Debugger.Soft.Rhino
+namespace MonoDevelop.RhinoDebug
 {
   enum McNeelProjectType
   {

--- a/MonoDevelop.RhinoDebug.csproj
+++ b/MonoDevelop.RhinoDebug.csproj
@@ -7,12 +7,12 @@
     <ProjectTypeGuids>{86F6BF2A-E449-4B3E-813B-9ACC37E5545F};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{E11789C7-BD3D-4BBE-86A1-8B5CEC452134}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>MonoDevelop.RhinoDebug</RootNamespace>
+    <RootNamespace>MonoDevelop.Debugger.Soft.Rhino</RootNamespace>
     <AssemblyName>MonoDevelop.RhinoDebug</AssemblyName>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <MDCoreVersionOverride>7.3</MDCoreVersionOverride>
+    <MDCoreVersionOverride>7.7</MDCoreVersionOverride>
     <CreatePackage>True</CreatePackage>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -45,9 +45,13 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Wizard\PluginWizard.cs" />
     <Compile Include="Wizard\ProvideSampleControl.cs" />
-    <Compile Include="Helpers.cs" />
     <Compile Include="RhinoGlobalProperties.cs" />
     <Compile Include="RhinoFileTemplate.cs" />
+    <Compile Include="RhinoRunConfiguration.cs" />
+    <Compile Include="RhinoExecutionCommand.cs" />
+    <Compile Include="RhinoExecutionHandler.cs" />
+    <Compile Include="Helpers.cs" />
+    <Compile Include="Wizard\RhinoVersionControl.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -63,24 +67,6 @@
     <None Include="addin-project.xml" />
     <None Include="README.md" />
     <None Include="packages.config" />
-  </ItemGroup>
-  <ProjectExtensions>
-    <MonoDevelop>
-      <Properties>
-        <Policies>
-          <TextStylePolicy inheritsSet="null" scope="text/x-csharp" />
-          <CSharpFormattingPolicy IndentBlock="True" IndentBraces="False" IndentSwitchSection="True" IndentSwitchCaseSection="True" LabelPositioning="OneLess" NewLinesForBracesInTypes="True" NewLinesForBracesInMethods="True" NewLinesForBracesInProperties="True" NewLinesForBracesInAccessors="True" NewLinesForBracesInAnonymousMethods="True" NewLinesForBracesInControlBlocks="True" NewLinesForBracesInAnonymousTypes="True" NewLinesForBracesInObjectCollectionArrayInitializers="True" NewLinesForBracesInLambdaExpressionBody="True" NewLineForElse="True" NewLineForCatch="True" NewLineForFinally="True" NewLineForMembersInObjectInit="True" NewLineForMembersInAnonymousTypes="True" NewLineForClausesInQuery="True" SpacingAfterMethodDeclarationName="False" SpaceWithinMethodDeclarationParenthesis="False" SpaceBetweenEmptyMethodDeclarationParentheses="False" SpaceAfterMethodCallName="False" SpaceWithinMethodCallParentheses="False" SpaceBetweenEmptyMethodCallParentheses="False" SpaceAfterControlFlowStatementKeyword="True" SpaceWithinExpressionParentheses="False" SpaceWithinCastParentheses="False" SpaceWithinOtherParentheses="False" SpaceAfterCast="False" SpacesIgnoreAroundVariableDeclaration="False" SpaceBeforeOpenSquareBracket="False" SpaceBetweenEmptySquareBrackets="False" SpaceWithinSquareBrackets="False" SpaceAfterColonInBaseTypeDeclaration="True" SpaceAfterComma="True" SpaceAfterDot="False" SpaceAfterSemicolonsInForStatement="True" SpaceBeforeColonInBaseTypeDeclaration="True" SpaceBeforeComma="False" SpaceBeforeDot="False" SpaceBeforeSemicolonsInForStatement="False" SpacingAroundBinaryOperator="Single" WrappingPreserveSingleLine="True" WrappingKeepStatementsOnSingleLine="True" PlaceSystemDirectiveFirst="True" scope="text/x-csharp" />
-          <TextStylePolicy FileWidth="120" RemoveTrailingWhitespace="True" NoTabsAfterNonTabs="False" EolMarker="Native" TabWidth="2" TabsToSpaces="True" IndentWidth="2" scope="text/plain" />
-        </Policies>
-      </Properties>
-    </MonoDevelop>
-  </ProjectExtensions>
-  <ItemGroup>
-    <Folder Include="Properties\" />
-    <Folder Include="Templates\" />
-    <Folder Include="Templates\Rhino\" />
-    <Folder Include="Templates\Grasshopper\" />
-    <Folder Include="Wizard\" />
   </ItemGroup>
   <ItemGroup>
     <AddinFile Include="Templates\Rhino\AssemblyInfo.cs" />

--- a/MonoDevelop.RhinoDebug.csproj
+++ b/MonoDevelop.RhinoDebug.csproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\MonoDevelop.Addins.0.4.4\build\MonoDevelop.Addins.props" Condition="Exists('packages\MonoDevelop.Addins.0.4.4\build\MonoDevelop.Addins.props')" />
+  <Import Project="packages\MonoDevelop.Addins.0.4.7\build\MonoDevelop.Addins.props" Condition="Exists('packages\MonoDevelop.Addins.0.4.7\build\MonoDevelop.Addins.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -52,6 +52,7 @@
     <Compile Include="RhinoExecutionHandler.cs" />
     <Compile Include="Helpers.cs" />
     <Compile Include="Wizard\RhinoVersionControl.cs" />
+    <Compile Include="OptionPanels\RhinoOptionsPanel.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -87,5 +88,8 @@
     <AddinReference Include="MonoDevelop.Debugger.Soft" />
     <AddinReference Include="MonoDevelop.CSharpBinding" />
   </ItemGroup>
-  <Import Project="packages\MonoDevelop.Addins.0.4.4\build\MonoDevelop.Addins.targets" Condition="Exists('packages\MonoDevelop.Addins.0.4.4\build\MonoDevelop.Addins.targets')" />
+  <ItemGroup>
+    <Folder Include="OptionPanels\" />
+  </ItemGroup>
+  <Import Project="packages\MonoDevelop.Addins.0.4.7\build\MonoDevelop.Addins.targets" Condition="Exists('packages\MonoDevelop.Addins.0.4.7\build\MonoDevelop.Addins.targets')" />
 </Project>

--- a/MonoDevelop.RhinoDebug.csproj
+++ b/MonoDevelop.RhinoDebug.csproj
@@ -7,7 +7,7 @@
     <ProjectTypeGuids>{86F6BF2A-E449-4B3E-813B-9ACC37E5545F};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{E11789C7-BD3D-4BBE-86A1-8B5CEC452134}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>MonoDevelop.Debugger.Soft.Rhino</RootNamespace>
+    <RootNamespace>MonoDevelop.RhinoDebug</RootNamespace>
     <AssemblyName>MonoDevelop.RhinoDebug</AssemblyName>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>

--- a/OptionPanels/RhinoOptionsPanel.cs
+++ b/OptionPanels/RhinoOptionsPanel.cs
@@ -5,7 +5,7 @@ using MonoDevelop.Components;
 using MonoDevelop.Ide.Gui.Dialogs;
 using MonoDevelop.Projects;
 
-namespace MonoDevelop.Debugger.Soft.Rhino.OptionPanels
+namespace MonoDevelop.RhinoDebug.OptionPanels
 {
   internal class RhinoOptionsPanel : ItemOptionsPanel
   {

--- a/OptionPanels/RhinoOptionsPanel.cs
+++ b/OptionPanels/RhinoOptionsPanel.cs
@@ -1,0 +1,294 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using MonoDevelop.Components;
+using MonoDevelop.Ide.Gui.Dialogs;
+using MonoDevelop.Projects;
+
+namespace MonoDevelop.Debugger.Soft.Rhino.OptionPanels
+{
+  internal class RhinoOptionsPanel : ItemOptionsPanel
+  {
+    RhinoOptionsPanelWidget widget;
+
+    public override bool IsVisible()
+    {
+      return ConfiguredProject.GetMcNeelProjectType(false) != null
+      || ConfiguredProject.ProjectProperties.GetProperty(Helpers.RhinoPluginTypeProperty) != null;
+    }
+
+    public override Control CreatePanelWidget()
+    {
+      widget = new RhinoOptionsPanelWidget((DotNetProject)ConfiguredProject, ItemConfigurations);
+
+      return widget;
+    }
+
+    public override void ApplyChanges()
+    {
+      widget.Store();
+    }
+  }
+
+  class RhinoOptionsPanelWidget : Gtk.VBox
+  {
+    Gtk.ComboBox pluginTypeCombo;
+    Gtk.ComboBox launcherCombo;
+    Gtk.Entry customLauncherEntry;
+    Gtk.Label autodetectedTypeLabel;
+    bool pluginTypeChanged;
+    bool launcherChanged;
+    DotNetProject project;
+    bool supportsDevelopment;
+    string[] currentLauncherEntries = defaultLauncherEntries;
+    static string[] typeEntries = { "Autodetect", "Rhino Plugin", "Grasshopper Component", "Library" };
+    static string[] defaultLauncherEntries = { "Autodetect", "Rhinoceros", "RhinoWIP", "Custom" };
+    static string[] debugLauncherEntries = { "XCode" };
+
+    string GetSelectedPluginType()
+    {
+      switch (pluginTypeCombo.Active)
+      {
+        case 0:
+          return null;
+        case 1:
+          return "rhp";
+        case 2:
+          return "gha";
+        case 3:
+        default:
+          return "none";
+      }
+    }
+
+    int GetPluginComboIndex()
+    {
+      var type = project.GetPluginProjectType();
+      if (type != null)
+      {
+        switch (type.Value)
+        {
+          case McNeelProjectType.None:
+            return 3;
+          case McNeelProjectType.RhinoCommon:
+            return 1;
+          case McNeelProjectType.Grasshopper:
+            return 2;
+        }
+      }
+      return 0;
+    }
+
+    int GetLauncherComboIndex()
+    {
+      var type = project.ProjectProperties.GetValue(Helpers.RhinoLauncherProperty);
+      if (!string.IsNullOrEmpty(type))
+      {
+        switch (type.ToLowerInvariant())
+        {
+          case "app":
+            return 1;
+          case "wip":
+            return 2;
+          case "xcode":
+            return supportsDevelopment ? 4 : 0;
+          default:
+            // custom
+            return 3;
+        }
+      }
+      return 0;
+    }
+
+    string GetTypeLabel(McNeelProjectType type)
+    {
+      switch (type)
+      {
+        case McNeelProjectType.None:
+          return "Library";
+        case McNeelProjectType.DebugStarter:
+          return "Rhino Development";
+        case McNeelProjectType.RhinoCommon:
+          return "Rhino Plugin";
+        case McNeelProjectType.Grasshopper:
+          return "Grasshopper Component";
+        default:
+          return null;
+      }
+    }
+
+    string GetSelectedLauncher()
+    {
+      switch (launcherCombo.Active)
+      {
+        default:
+        case 0:
+          return null;
+        case 1:
+          return "app";
+        case 2:
+          return "wip";
+        case 3:
+          return customLauncherEntry.Text;
+        case 4:
+          return "xcode";
+      }
+    }
+
+    public void Store()
+    {
+      if (pluginTypeChanged)
+      {
+        var pluginType = GetSelectedPluginType();
+        if (pluginType != null)
+          project.ProjectProperties.SetValue(Helpers.RhinoPluginTypeProperty, pluginType);
+        else
+          project.ProjectProperties.RemoveProperty(Helpers.RhinoPluginTypeProperty);
+
+        project.NeedsReload = true;
+      }
+
+      if (launcherChanged)
+      {
+        var launcherType = GetSelectedLauncher();
+        if (launcherType != null)
+          project.ProjectProperties.SetValue(Helpers.RhinoLauncherProperty, launcherType);
+        else
+          project.ProjectProperties.RemoveProperty(Helpers.RhinoLauncherProperty);
+      }
+    }
+
+    public RhinoOptionsPanelWidget(DotNetProject project, IEnumerable<ItemConfiguration> configurations)
+    {
+      supportsDevelopment = project.GetMcNeelProjectType() == McNeelProjectType.DebugStarter;
+
+      if (supportsDevelopment)
+        currentLauncherEntries = currentLauncherEntries.Concat(debugLauncherEntries).ToArray();
+
+      this.project = project;
+      Build();
+
+      pluginTypeCombo.Active = GetPluginComboIndex();
+      pluginTypeCombo.Changed += (sender, e) =>
+      {
+        pluginTypeChanged = true;
+        SetAutodetectLabel();
+      };
+      SetAutodetectLabel();
+
+
+      launcherCombo.Changed += (sender, e) =>
+      {
+        launcherChanged = true;
+        SetCustomLauncherText();
+      };
+      launcherCombo.Active = GetLauncherComboIndex();
+      SetCustomLauncherText();
+    }
+
+    void SetCustomLauncherText()
+    {
+      customLauncherEntry.IsEditable = launcherCombo.Active == 3; // custom
+      var outputFileName = project.GetOutputFileName(project.DefaultConfiguration.Selector);
+      switch (launcherCombo.Active)
+      {
+        case 0:
+          // auto detect
+          var version = project.GetRhinoVersion() ?? Helpers.DefaultRhinoVersion;
+          var appPath = project.DetectApplicationPath(outputFileName, version);
+          customLauncherEntry.Text = appPath;
+          break;
+        case 1:
+          customLauncherEntry.Text = Helpers.StandardInstallPath;
+          break;
+        case 2:
+          customLauncherEntry.Text = Helpers.StandardInstallWipPath;
+          break;
+        case 3:
+          var currentLauncherIndex = GetLauncherComboIndex();
+          if (currentLauncherIndex == 3) // custom
+            customLauncherEntry.Text = project.ProjectProperties.GetValue(Helpers.RhinoLauncherProperty);
+          else
+            customLauncherEntry.Text = string.Empty;
+          break;
+        case 4:
+          customLauncherEntry.Text = Helpers.GetXcodeDerivedDataPath(outputFileName);
+          break;
+      }
+    }
+
+    void SetAutodetectLabel()
+    {
+      if (pluginTypeCombo.Active == 0) // autodetect
+      {
+        var detectedType = project.GetMcNeelProjectType(false);
+        if (detectedType != null)
+        {
+          autodetectedTypeLabel.Markup = $"Detected: <b>{GetTypeLabel(detectedType.Value)}</b>";
+        }
+      }
+      else
+      {
+        autodetectedTypeLabel.Text = string.Empty;
+      }
+    }
+
+    void Build()
+    {
+      Spacing = 6;
+
+      //var heading = new Gtk.Label("<b>Rhino Options</b>");
+      //heading.UseMarkup = true;
+      //heading.Xalign = 0;
+
+
+
+      pluginTypeCombo = new Gtk.ComboBox(typeEntries);
+
+      launcherCombo = new Gtk.ComboBox(currentLauncherEntries);
+
+      customLauncherEntry = new Gtk.Entry();
+
+      var optionsBox = new Gtk.HBox();
+
+      autodetectedTypeLabel = new Gtk.Label();
+
+      // layout
+
+      //PackStart(heading, false, false, 0);
+
+
+      var table = new Gtk.Table(3, 3, false);
+      table.RowSpacing = 6;
+      table.ColumnSpacing = 6;
+
+      table.Attach(new Gtk.Label("Plugin Type:") { Xalign = 1 }, 0, 1, 0, 1);
+      table.Attach(AutoSized(6, pluginTypeCombo, autodetectedTypeLabel), 1, 2, 0, 1);
+
+      table.Attach(new Gtk.Label("Launcher:") { Xalign = 1 }, 0, 1, 1, 2);
+      table.Attach(AutoSized(6, launcherCombo), 1, 2, 1, 2);
+
+      table.Attach(new Gtk.Label(), 0, 1, 2, 3);
+      table.Attach(customLauncherEntry, 1, 2, 2, 3);
+
+      // indent
+      optionsBox.PackStart(new Gtk.Label { WidthRequest = 18 }, false, false, 0);
+      optionsBox.PackStart(table, false, true, 0);
+
+      PackStart(optionsBox, true, true, 0);
+
+      ShowAll();
+    }
+
+    Gtk.HBox AutoSized(int spacing, params Gtk.Widget[] widgets)
+    {
+      var box = new Gtk.HBox();
+      box.Spacing = spacing;
+      foreach (var widget in widgets)
+      {
+        box.PackStart(widget, false, true, 0);
+      }
+      return box;
+    }
+  }
+}

--- a/Properties/AddinInfo.cs
+++ b/Properties/AddinInfo.cs
@@ -9,7 +9,7 @@ using Mono.Addins;
 // the same stable release of Xamarin Studio.
 [assembly:Addin(
   "RhinoXamarinStudioAddIn",
-	Version = "7.4.3.1"
+	Version = "7.7.4.0"
 )]
 
 // This controls the displayed name in the Xamarin Studio Add-In Manager...

--- a/Properties/Manifest.addin.xml
+++ b/Properties/Manifest.addin.xml
@@ -19,6 +19,13 @@
   <Extension path = "/MonoDevelop/ProjectModel/ProjectModelExtensions">
     <Class class = "MonoDevelop.Debugger.Soft.Rhino.RhinoProjectServiceExtension" />
   </Extension>
+    
+  <Extension path = "/MonoDevelop/ProjectModel/Gui/ItemOptionPanels/Build">
+    <Section id="Rhino" _label="Rhino">
+      <Panel id = "RhinoOptionsPanel" _label = "Rhino Options" class = "MonoDevelop.Debugger.Soft.Rhino.OptionPanels.RhinoOptionsPanel"/>
+    </Section>
+  </Extension>
+                
 
   <Extension path="/MonoDevelop/Ide/ProjectTemplates">
     <ProjectTemplate id="Rhino.Plugin" file="Templates/Rhino/Plugin.xpt.xml" />

--- a/Properties/Manifest.addin.xml
+++ b/Properties/Manifest.addin.xml
@@ -1,13 +1,21 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ExtensionModel>
+  <Extension path="/MonoDevelop/Core/ExecutionHandlers">
+    <ExecutionHandler id="Rhino" class="MonoDevelop.Debugger.Soft.Rhino.RhinoExecutionHandler" insertbefore="Platform" />
+  </Extension>
+  
+  <Extension path = "/MonoDevelop/Ide/RunConfigurationEditors">
+    <Class class="MonoDevelop.Ide.Projects.OptionPanels.AssemblyRunConfigurationEditor" runConfigurationType="MonoDevelop.Debugger.Soft.Rhino.RhinoRunConfiguration" />
+  </Extension>
+  
   <Extension path="/MonoDevelop/Debugging/DebuggerEngines">
     <DebuggerEngine
       id="Mono.Debugger.Soft.Rhino"
       name="RhinoCommon Plug-In Debugger"
-      features="Breakpoints, Pause, Stepping, DebugFile, Catchpoints"
+      features="Breakpoints, Pause, Stepping, DebugFile, ConditionalBreakpoints, Tracepoints, Catchpoints, Disassembly"
       type="MonoDevelop.Debugger.Soft.Rhino.RhinoSoftDebuggerEngine" />
   </Extension>
-
+  
   <Extension path = "/MonoDevelop/ProjectModel/ProjectModelExtensions">
     <Class class = "MonoDevelop.Debugger.Soft.Rhino.RhinoProjectServiceExtension" />
   </Extension>

--- a/Properties/Manifest.addin.xml
+++ b/Properties/Manifest.addin.xml
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ExtensionModel>
   <Extension path="/MonoDevelop/Core/ExecutionHandlers">
-    <ExecutionHandler id="Rhino" class="MonoDevelop.Debugger.Soft.Rhino.RhinoExecutionHandler" insertbefore="Platform" />
+    <ExecutionHandler id="Rhino" class="MonoDevelop.RhinoDebug.RhinoExecutionHandler" insertbefore="Platform" />
   </Extension>
   
   <Extension path = "/MonoDevelop/Ide/RunConfigurationEditors">
-    <Class class="MonoDevelop.Ide.Projects.OptionPanels.AssemblyRunConfigurationEditor" runConfigurationType="MonoDevelop.Debugger.Soft.Rhino.RhinoRunConfiguration" />
+    <Class class="MonoDevelop.Ide.Projects.OptionPanels.AssemblyRunConfigurationEditor" runConfigurationType="MonoDevelop.RhinoDebug.RhinoRunConfiguration" />
   </Extension>
   
   <Extension path="/MonoDevelop/Debugging/DebuggerEngines">
@@ -13,16 +13,16 @@
       id="Mono.Debugger.Soft.Rhino"
       name="RhinoCommon Plug-In Debugger"
       features="Breakpoints, Pause, Stepping, DebugFile, ConditionalBreakpoints, Tracepoints, Catchpoints, Disassembly"
-      type="MonoDevelop.Debugger.Soft.Rhino.RhinoSoftDebuggerEngine" />
+      type="MonoDevelop.RhinoDebug.RhinoSoftDebuggerEngine" />
   </Extension>
   
   <Extension path = "/MonoDevelop/ProjectModel/ProjectModelExtensions">
-    <Class class = "MonoDevelop.Debugger.Soft.Rhino.RhinoProjectServiceExtension" />
+    <Class class = "MonoDevelop.RhinoDebug.RhinoProjectServiceExtension" />
   </Extension>
     
   <Extension path = "/MonoDevelop/ProjectModel/Gui/ItemOptionPanels/Build">
     <Section id="Rhino" _label="Rhino">
-      <Panel id = "RhinoOptionsPanel" _label = "Rhino Options" class = "MonoDevelop.Debugger.Soft.Rhino.OptionPanels.RhinoOptionsPanel"/>
+      <Panel id = "RhinoOptionsPanel" _label = "Rhino Options" class = "MonoDevelop.RhinoDebug.OptionPanels.RhinoOptionsPanel"/>
     </Section>
   </Extension>
                 

--- a/RhinoDebuggerStartInfo.cs
+++ b/RhinoDebuggerStartInfo.cs
@@ -25,9 +25,6 @@ namespace MonoDevelop.Debugger.Soft.Rhino
       ExecutablePath = cmd.ExecutablePath;
     }
 
-    public bool ContainsCustomStartArgs => !string.IsNullOrWhiteSpace(Arguments);
-
-
     public string ApplicationPath { get; private set; }
     public string ExecutablePath { get; private set; }
     public string TargetDirectory { get; private set; }

--- a/RhinoDebuggerStartInfo.cs
+++ b/RhinoDebuggerStartInfo.cs
@@ -8,56 +8,33 @@ namespace MonoDevelop.Debugger.Soft.Rhino
 {
   class RhinoDebuggerStartInfo : Mono.Debugging.Soft.SoftDebuggerStartInfo
   {
-    string m_start_args;
-
-    public RhinoDebuggerStartInfo(string appName, string startArgs, string binDir, string pluginPath, string rhinocommonPath, bool isGrasshopper)
-      : base(new Mono.Debugging.Soft.SoftDebuggerListenArgs(appName, System.Net.IPAddress.Loopback, 0))
+    public RhinoDebuggerStartInfo(RhinoExecutionCommand cmd)
+      : base(new Mono.Debugging.Soft.SoftDebuggerListenArgs("Rhino", System.Net.IPAddress.Loopback, 0))
     {
-      m_start_args = startArgs;
-      PluginPath = pluginPath;
-      TargetDirectory = binDir;
-      RhinoCommonPath = rhinocommonPath;
-      IsGrasshopper = isGrasshopper;
-    }
-
-    public bool ContainsCustomStartArgs
-    {
-      get
+      Arguments = cmd.Arguments;
+      PluginPath = cmd.PluginPath;
+      TargetDirectory = cmd.BinDir;
+      RhinoCommonPath = cmd.RhinoCommonPath;
+      IsGrasshopper = cmd.IsGrasshopper;
+      RhinoVersion = cmd.RhinoVersion;
+      foreach (var env in cmd.EnvironmentVariables)
       {
-        return !string.IsNullOrWhiteSpace(m_start_args);
+        EnvironmentVariables.Add(env.Key, env.Value);
       }
+      ApplicationPath = cmd.ApplicationPath;
+      ExecutablePath = cmd.ExecutablePath;
     }
 
-    /// <summary>
-    /// Full path to the Rhinoceros executable to start
-    /// </summary>
-    public string GetApplicationPath()
-    {
-      // always attempt to run the Rhino that contains the RhinoCommon we are referencing first
-      // only command line args can override this behavior
+    public bool ContainsCustomStartArgs => !string.IsNullOrWhiteSpace(Arguments);
 
-      if (string.IsNullOrEmpty(m_start_args) && !string.IsNullOrEmpty(RhinoCommonPath))
-      {
-        var fileinfo = new System.IO.FileInfo(RhinoCommonPath);
-        if (fileinfo.Exists)
-        {
-          var contents_dir = fileinfo.Directory.Parent;
-          string path = System.IO.Path.Combine(contents_dir.FullName, "MacOS", "Rhinoceros");
-          if (System.IO.File.Exists(path))
-            return path;
-        }
-      }
 
-      // The actual executable name changed in the past from Rhino to Rhinoceros.
-      // Just check for both
-      return Helpers.GetAppPath(m_start_args, "Contents/MacOS/Rhinoceros", TargetDirectory)
-                    ?? Helpers.GetAppPath(m_start_args, "Contents/MacOS/Rhino", TargetDirectory);
-    }
-
+    public string ApplicationPath { get; private set; }
+    public string ExecutablePath { get; private set; }
     public string TargetDirectory { get; private set; }
     public string PluginPath { get; private set; }
     public string RhinoCommonPath { get; private set; }
     public bool IsGrasshopper { get; private set; }
+    public int RhinoVersion { get; private set; }
   }
 }
 

--- a/RhinoDebuggerStartInfo.cs
+++ b/RhinoDebuggerStartInfo.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using MonoDevelop.Projects;
 using System.Collections.Generic;
 
-namespace MonoDevelop.Debugger.Soft.Rhino
+namespace MonoDevelop.RhinoDebug
 {
   class RhinoDebuggerStartInfo : Mono.Debugging.Soft.SoftDebuggerStartInfo
   {

--- a/RhinoExecutionCommand.cs
+++ b/RhinoExecutionCommand.cs
@@ -1,0 +1,201 @@
+﻿using MonoDevelop.Projects;
+using MonoDevelop.Core.Execution;
+using System.Collections.Generic;
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml;
+
+namespace MonoDevelop.Debugger.Soft.Rhino
+{
+  class RhinoExecutionCommand : ProcessExecutionCommand
+  {
+    string _applicationPath;
+
+    public DotNetProject Project { get; set; }
+
+    public bool IsGrasshopper { get; set; }
+
+    public string RhinoCommonPath { get; set; }
+
+    public string PluginPath { get; set; }
+
+    public string BinDir { get; set; }
+
+    public int RhinoVersion { get; set; }
+
+    public string ApplicationPath => _applicationPath ?? (_applicationPath = GetApplicationPath());
+
+    public string ExecutablePath => Path.Combine(ApplicationPath, "Contents/MacOS/Rhinoceros");
+
+    public RhinoExecutionCommand(DotNetProject project, string workingDirectory, string outputname, string startArguments, IDictionary<string, string> environmentVariables)
+    {
+      Project = project;
+      Arguments = startArguments;
+      WorkingDirectory = workingDirectory;
+      Command = outputname;
+      RhinoVersion = project.GetRhinoVersion() ?? Helpers.DefaultRhinoVersion;
+
+      for (int i = 0; i < Project.References.Count; i++)
+      {
+        var reference = Project.References[i];
+        if (reference.HintPath != null && reference.HintPath.FileNameWithoutExtension == Helpers.RhinoCommonReferenceName)
+        {
+          RhinoCommonPath = reference.HintPath;
+        }
+        if (reference.HintPath != null && reference.HintPath.FileNameWithoutExtension == Helpers.GrasshopperReferenceName)
+        {
+          IsGrasshopper = true;
+        }
+      }
+
+      string target = Command;
+      if (!string.IsNullOrWhiteSpace(target) && System.IO.File.Exists(target))
+      {
+        PluginPath = target;
+        BinDir = System.IO.Path.GetDirectoryName(target);
+      }
+
+      EnvironmentVariables = environmentVariables != null ? new Dictionary<string, string>(environmentVariables) : new Dictionary<string, string>();
+
+      if (!string.IsNullOrEmpty(BinDir))
+      {
+        EnvironmentVariables["RHINO_BIN_DIRECTORY"] = BinDir;
+      }
+      if (!string.IsNullOrEmpty(PluginPath))
+      {
+        if (IsGrasshopper)
+          EnvironmentVariables["GRASSHOPPER_PLUGINS"] = PluginPath;
+        else
+          EnvironmentVariables["RHINO_PLUGIN_PATH"] = PluginPath;
+      }
+    }
+
+    /// <summary>
+    /// Full path to the Rhinoceros executable to start
+    /// </summary>
+    string GetApplicationPath()
+    {
+      // always attempt to run the Rhino that contains the RhinoCommon we are referencing first
+      // only command line args can override this behavior
+
+      if (string.IsNullOrEmpty(Arguments) && !string.IsNullOrEmpty(RhinoCommonPath))
+      {
+        var fileinfo = new System.IO.FileInfo(RhinoCommonPath);
+        if (fileinfo.Exists)
+        {
+          var contents_dir = fileinfo.Directory.Parent;
+          string path = System.IO.Path.Combine(contents_dir.FullName, "MacOS", "Rhinoceros");
+          if (System.IO.File.Exists(path))
+            return path;
+        }
+      }
+
+      string appPath;
+      if (Arguments != null && Arguments.StartsWith("-xcode", StringComparison.Ordinal))
+      {
+        // get output path
+        appPath = GetXcodeDerivedDataPath(BinDir);
+      }
+      else if (Arguments != null && Arguments.StartsWith("-app_path=", StringComparison.Ordinal))
+      {
+        string path = Arguments.Substring("-app_path=".Length);
+        path = path.Trim(new char[] { '\"', ' ' });
+        appPath = path;
+      }
+      else if (Arguments != null && Arguments.StartsWith("-wip", StringComparison.Ordinal))
+      {
+        appPath = Helpers.StandardInstallWipPath;
+      }
+      else if (Arguments != null && Arguments.StartsWith("-app", StringComparison.Ordinal))
+      {
+        appPath = Helpers.StandardInstallPath;
+      }
+      else
+      {
+        appPath = GetXcodeDerivedDataPath(BinDir);
+        if (appPath == null && RhinoVersion > Helpers.DefaultRhinoVersion)
+          appPath = Helpers.StandardInstallWipPath;
+        if (appPath == null)
+          appPath = Helpers.StandardInstallPath;
+      }
+      return Directory.Exists(appPath) || File.Exists(appPath) ? appPath : null;
+    }
+
+
+    public static string GetXcodeDerivedDataPath(string targetDirectory)
+    {
+      var homePath = Environment.GetEnvironmentVariable("HOME");
+      var derivedDataPath = Path.Combine(homePath, "Library", "Developer", "Xcode", "DerivedData");
+      if (!Directory.Exists(derivedDataPath))
+        return null;
+
+      var dataPaths = Directory.GetDirectories(derivedDataPath).Where(r => Path.GetFileName(r).StartsWith("MacRhino-", StringComparison.Ordinal));
+      foreach (var dataPath in dataPaths)
+      {
+        if (dataPath == null)
+          continue;
+
+        // load up info.plist to get WorkspacePath and compare with our target directory
+        try
+        {
+          var infoPath = Path.Combine(dataPath, "info.plist");
+          var doc = new XmlDocument();
+          doc.Load(infoPath);
+          var workspacePath = doc.SelectSingleNode("plist/dict/key[.='WorkspacePath']/following-sibling::string[1]")?.InnerText;
+
+          var workspaceDir = new DirectoryInfo(workspacePath);
+          if (!workspaceDir.Exists)
+            continue;
+
+          var commonPath = FindCommonPath(Path.DirectorySeparatorChar, new[] { workspacePath, targetDirectory });
+
+          // assume the workspacePath points to MacRhino.xcodeproj, so check based on its parent folder, which should be src4.
+          if (commonPath == workspaceDir.Parent?.Parent?.FullName)
+          {
+            var appPath = Path.Combine(dataPath, "Build", "Products", "Debug", "Rhinoceros.app");
+
+            if (Directory.Exists(appPath))
+              return appPath;
+          }
+        }
+        catch
+        {
+          continue;
+        }
+      }
+      return null;
+    }
+
+    public static string FindCommonPath(char separator, IEnumerable<string> paths)
+    {
+      string commonPath = String.Empty;
+      var separatedPaths = paths
+        .First(str => str.Length == paths.Max(st2 => st2.Length))
+        .Split(new[] { separator }, StringSplitOptions.RemoveEmptyEntries)
+        .ToList();
+
+      foreach (string segment in separatedPaths)
+      {
+        if (commonPath.Length == 0 && paths.All(str => str.StartsWith(segment, StringComparison.Ordinal)))
+        {
+          commonPath = segment;
+        }
+        else if (paths.All(str => str.StartsWith(commonPath + separator + segment, StringComparison.Ordinal)))
+        {
+          commonPath += separator + segment;
+        }
+        else
+        {
+          break;
+        }
+      }
+
+      return commonPath;
+    }
+
+
+
+  }
+}
+

--- a/RhinoExecutionCommand.cs
+++ b/RhinoExecutionCommand.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 
-namespace MonoDevelop.Debugger.Soft.Rhino
+namespace MonoDevelop.RhinoDebug
 {
   class RhinoExecutionCommand : ProcessExecutionCommand
   {

--- a/RhinoExecutionHandler.cs
+++ b/RhinoExecutionHandler.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Linq;
+using MonoDevelop.Core;
+using MonoDevelop.Core.Execution;
+
+namespace MonoDevelop.Debugger.Soft.Rhino
+{
+  public class RhinoExecutionHandler : NativePlatformExecutionHandler
+  {
+    public override bool CanExecute(ExecutionCommand command)
+    {
+      return command is RhinoExecutionCommand;
+    }
+
+    public override ProcessAsyncOperation Execute(ExecutionCommand command, OperationConsole console)
+    {
+      // run without debugger
+      var cmd = (RhinoExecutionCommand)command;
+
+      var nativeCmd = new NativeExecutionCommand(cmd.ExecutablePath, cmd.Arguments, cmd.WorkingDirectory, cmd.EnvironmentVariables);
+      return base.Execute(nativeCmd, console);
+    }
+  }
+}

--- a/RhinoExecutionHandler.cs
+++ b/RhinoExecutionHandler.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using MonoDevelop.Core;
 using MonoDevelop.Core.Execution;
 
-namespace MonoDevelop.Debugger.Soft.Rhino
+namespace MonoDevelop.RhinoDebug
 {
   public class RhinoExecutionHandler : NativePlatformExecutionHandler
   {

--- a/RhinoGlobalProperties.cs
+++ b/RhinoGlobalProperties.cs
@@ -4,7 +4,7 @@ using Mono.Addins;
 using MonoDevelop.Core;
 using MonoDevelop.Projects.MSBuild;
 
-namespace MonoDevelop.Debugger.Soft.Rhino
+namespace MonoDevelop.RhinoDebug
 {
   [Extension("/MonoDevelop/ProjectModel/MSBuildGlobalPropertyProviders")]
   public class RhinoGlobalProperties : IMSBuildGlobalPropertyProvider

--- a/RhinoGlobalProperties.cs
+++ b/RhinoGlobalProperties.cs
@@ -28,7 +28,7 @@ namespace MonoDevelop.Debugger.Soft.Rhino
         if (s_requiresMdb != value)
         {
           s_requiresMdb = value;
-          instance.GlobalPropertiesChanged?.Invoke(instance, EventArgs.Empty);
+          Runtime.RunInMainThread(() => instance.GlobalPropertiesChanged?.Invoke(instance, EventArgs.Empty));
         }
       }
     }

--- a/RhinoProjectServiceExtension.cs
+++ b/RhinoProjectServiceExtension.cs
@@ -6,7 +6,7 @@ using MonoDevelop.Debugger;
 using MonoDevelop.Ide;
 using MonoDevelop.Core.Execution;
 using Mono.Debugging.Client;
-using MonoDevelop.Debugger.Soft.Rhino;
+using MonoDevelop.RhinoDebug;
 using System.Reflection;
 using System.IO;
 using MonoDevelop.Projects.MSBuild;
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 
 
-namespace MonoDevelop.Debugger.Soft.Rhino
+namespace MonoDevelop.RhinoDebug
 {
 
   public class RhinoProjectServiceExtension : DotNetProjectExtension

--- a/RhinoProjectServiceExtension.cs
+++ b/RhinoProjectServiceExtension.cs
@@ -33,6 +33,11 @@ namespace MonoDevelop.Debugger.Soft.Rhino
       SetRequiresMdb();
     }
 
+    protected override DotNetProjectFlags OnGetDotNetProjectFlags()
+    {
+      return base.OnGetDotNetProjectFlags() | DotNetProjectFlags.IsLibrary;
+    }
+
     protected override Task OnExecuteCommand(ProgressMonitor monitor, ExecutionContext context, ConfigurationSelector configuration, ExecutionCommand executionCommand)
     {
       if (IsSupportedProject)
@@ -187,7 +192,7 @@ namespace MonoDevelop.Debugger.Soft.Rhino
             if (File.Exists(debugFile))
               File.Delete(debugFile);
 
-            debugFile = file.ChangeExtension(".pdb");
+            debugFile = file.ChangeExtension(ext + ".pdb");
             if (File.Exists(debugFile))
               File.Delete(debugFile);
           }

--- a/RhinoProjectServiceExtension.cs
+++ b/RhinoProjectServiceExtension.cs
@@ -16,14 +16,6 @@ using System.Collections.Generic;
 
 namespace MonoDevelop.Debugger.Soft.Rhino
 {
-  class RhinoCommonExecutionCommand : DotNetExecutionCommand
-  {
-    public DotNetProject Project { get; set; }
-    public RhinoCommonExecutionCommand(string outputname, DotNetProject project) : base(outputname)
-    {
-      Project = project;
-    }
-  }
 
   public class RhinoProjectServiceExtension : DotNetProjectExtension
   {
@@ -41,41 +33,44 @@ namespace MonoDevelop.Debugger.Soft.Rhino
       SetRequiresMdb();
     }
 
-    protected override Task OnExecute(ProgressMonitor monitor, ExecutionContext context, ConfigurationSelector configuration, SolutionItemRunConfiguration runConfiguration)
+    protected override Task OnExecuteCommand(ProgressMonitor monitor, ExecutionContext context, ConfigurationSelector configuration, ExecutionCommand executionCommand)
     {
-      if (base.OnGetCanExecute(context, configuration, runConfiguration))
+      if (IsSupportedProject)
+        return OnExecuteRhinoCommand(monitor, context, configuration, executionCommand);
+
+      return base.OnExecuteCommand(monitor, context, configuration, executionCommand);
+    }
+
+    async Task OnExecuteRhinoCommand(ProgressMonitor monitor, ExecutionContext context, ConfigurationSelector configuration, ExecutionCommand executionCommand)
+    {
+      bool externalConsole = false;
+      bool pauseConsole = false;
+
+      var rhinoExecutionCommand = executionCommand as RhinoExecutionCommand;
+      if (rhinoExecutionCommand != null)
       {
-        return base.OnExecute(monitor, context, configuration, runConfiguration);
+        //externalConsole = rhinoExecutionCommand.ExternalConsole;
+        //pauseConsole = rhinoExecutionCommand.PauseConsoleOutput;
       }
 
-      try
-      {
-        var project = Project as DotNetProject;
-        if (project != null && IsSupportedProject)
-        {
-          const string SoftDebuggerName = RhinoSoftDebuggerEngine.DebuggerName;
-          var config = project.GetConfiguration(configuration) as DotNetProjectConfiguration;
-          var cmd = new RhinoCommonExecutionCommand(project.GetOutputFileName(configuration), project);
-          cmd.Arguments = config.CommandLineParameters;
-          cmd.WorkingDirectory = Path.GetDirectoryName(config.CompiledOutputName);
-          cmd.EnvironmentVariables = config.GetParsedEnvironmentVariables();
-          cmd.TargetRuntime = project.TargetRuntime;
-          cmd.UserAssemblyPaths = project.GetUserAssemblyPaths(configuration);
+      OperationConsole console = externalConsole ? context.ExternalConsoleFactory.CreateConsole(!pauseConsole, monitor.CancellationToken)
+        : context.ConsoleFactory.CreateConsole(OperationConsoleFactory.CreateConsoleOptions.Default.WithTitle(Project.Name), monitor.CancellationToken);
 
-          var executionModes = Runtime.ProcessService.GetExecutionModes();
-          var executionMode = executionModes.SelectMany(r => r.ExecutionModes).FirstOrDefault(r => r.Id == SoftDebuggerName);
-          var console = context.ConsoleFactory.CreateConsole(new OperationConsoleFactory.CreateConsoleOptions(true));
-          var operation = executionMode.ExecutionHandler.Execute(cmd, console);
-          monitor.CancellationToken.Register(() => operation.Cancel());
-          return operation.Task;
+      using (console)
+      {
+        ProcessAsyncOperation asyncOp = context.ExecutionHandler.Execute(executionCommand, console);
+
+        try
+        {
+          using (var stopper = monitor.CancellationToken.Register(asyncOp.Cancel))
+            await asyncOp.Task;
+
+          monitor.Log.WriteLine(GettextCatalog.GetString("The application exited with code: {0}", asyncOp.ExitCode));
+        }
+        catch (OperationCanceledException)
+        {
         }
       }
-      catch (Exception ex)
-      {
-        monitor.ReportError($"An error occurred starting Rhino.\n{ex}", ex);
-        return null; // is this correct??  I can't seem to get VS on Mac to actually show the error.
-      }
-      return base.OnExecute(monitor, context, configuration, runConfiguration);
     }
 
     protected override FilePath OnGetOutputFileName(ConfigurationSelector configuration)
@@ -89,17 +84,6 @@ namespace MonoDevelop.Debugger.Soft.Rhino
 		bool IsSupportedProject => Project.GetMcNeelProjectType() != null;
 
     int? RhinoVersion => Project.GetRhinoVersion();
-
-    bool IsPlugin
-    {
-      get
-      {
-        if (Project.ProjectProperties.GetValue<bool>("RhinoPlugin"))
-          return true;
-        // check for nuget package
-        return false;
-      }
-    }
 
     bool RequiresMdb => RhinoVersion < 6;
 
@@ -132,6 +116,7 @@ namespace MonoDevelop.Debugger.Soft.Rhino
           {
             RenameOutputFile(file, file.ChangeExtension(ext));
 						RenameOutputFile(file.ChangeExtension(file.Extension + ".mdb"), file.ChangeExtension(ext + ".mdb"));
+            RenameOutputFile(file.ChangeExtension(".pdb"), file.ChangeExtension(ext + ".pdb"));
           }
         }
       }
@@ -140,6 +125,42 @@ namespace MonoDevelop.Debugger.Soft.Rhino
         monitor.ReportError($"An error occurred renaming output files to .rhi/.ghp.\n{ex}", ex);
       }
       return result;
+    }
+
+    protected override ProjectRunConfiguration OnCreateRunConfiguration(string name)
+    {
+      return new RhinoRunConfiguration(name);
+    }
+
+    protected override ExecutionCommand OnCreateExecutionCommand(ConfigurationSelector configSel, DotNetProjectConfiguration configuration, ProjectRunConfiguration runConfiguration)
+    {
+      if (IsSupportedProject)
+      {
+        return CreateRhinoExecutionCommand(configSel, configuration, runConfiguration);
+      }
+
+      return base.OnCreateExecutionCommand(configSel, configuration, runConfiguration);
+    }
+
+
+    RhinoExecutionCommand CreateRhinoExecutionCommand(ConfigurationSelector configSel, DotNetProjectConfiguration configuration, ProjectRunConfiguration runConfiguration)
+    {
+      FilePath outputFileName;
+      var rhinoRunConfiguration = runConfiguration as RhinoRunConfiguration;
+      if (rhinoRunConfiguration?.StartAction == AssemblyRunConfiguration.StartActions.Program)
+        outputFileName = rhinoRunConfiguration.StartProgram;
+      else
+        outputFileName = Project.GetOutputFileName(configuration.Selector);
+
+
+      // find the rhino to use!
+      return new RhinoExecutionCommand(
+        Project,
+        string.IsNullOrEmpty(rhinoRunConfiguration?.StartWorkingDirectory) ? Project.BaseDirectory : rhinoRunConfiguration.StartWorkingDirectory,
+        outputFileName,
+        rhinoRunConfiguration?.StartArguments,
+        rhinoRunConfiguration?.EnvironmentVariables
+      );
     }
 
     protected override async Task<BuildResult> OnClean(ProgressMonitor monitor, ConfigurationSelector configuration, OperationContext operationContext)
@@ -161,7 +182,12 @@ namespace MonoDevelop.Debugger.Soft.Rhino
             var assemblyFile = file.ChangeExtension(ext);
             if (File.Exists(assemblyFile))
               File.Delete(assemblyFile);
+
 						var debugFile = file.ChangeExtension(ext + ".mdb");
+            if (File.Exists(debugFile))
+              File.Delete(debugFile);
+
+            debugFile = file.ChangeExtension(".pdb");
             if (File.Exists(debugFile))
               File.Delete(debugFile);
           }
@@ -193,31 +219,6 @@ namespace MonoDevelop.Debugger.Soft.Rhino
       return features;
     }
 
-    protected override bool OnGetCanExecute(ExecutionContext context, ConfigurationSelector configuration, SolutionItemRunConfiguration runConfiguration)
-    {
-      bool res = base.OnGetCanExecute(context, configuration, runConfiguration);
-      if (res)
-        return true;
-
-      var dotNetProject = Project as DotNetProject;
-      if (dotNetProject == null || !IsSupportedProject)
-        return false;
-
-      var config = dotNetProject.GetConfiguration(configuration) as DotNetProjectConfiguration;
-      if (config == null)
-        return false;
-
-			var projectRun = dotNetProject.GetDefaultRunConfiguration() as ProjectRunConfiguration;
-      var cmd = dotNetProject.CreateExecutionCommand(configuration, config, projectRun);
-      if (context.ExecutionTarget != null)
-        cmd.Target = context.ExecutionTarget;
-      if (context.ExecutionHandler == null)
-        return false;
-
-      var result = context.ExecutionHandler.CanExecute(cmd);
-
-      return result;
-    }
   }
 }
 

--- a/RhinoRunConfiguration.cs
+++ b/RhinoRunConfiguration.cs
@@ -1,0 +1,35 @@
+﻿using MonoDevelop.Components;
+using MonoDevelop.Ide.Gui.Dialogs;
+using MonoDevelop.Projects;
+
+
+namespace MonoDevelop.Debugger.Soft.Rhino
+{
+  internal class RhinoRunConfigurationEditor : MonoDevelop.Ide.Projects.OptionPanels.RunConfigurationPanel
+  {
+    public override Control CreatePanelWidget()
+    {
+      return base.CreatePanelWidget();
+    }
+
+    public override void Initialize(OptionsDialog dialog, object dataObject)
+    {
+      base.Initialize(dialog, dataObject);
+    }
+  }
+
+  internal class RhinoRunConfiguration : AssemblyRunConfiguration
+  {
+    public override bool CanRunLibrary => true;
+
+    public RhinoRunConfiguration(string name) : base(name)
+    {
+    }
+
+    protected override void OnCopyFrom(ProjectRunConfiguration config, bool isRename)
+    {
+      base.OnCopyFrom(config, isRename);
+    }
+  }
+}
+

--- a/RhinoRunConfiguration.cs
+++ b/RhinoRunConfiguration.cs
@@ -25,11 +25,6 @@ namespace MonoDevelop.Debugger.Soft.Rhino
     public RhinoRunConfiguration(string name) : base(name)
     {
     }
-
-    protected override void OnCopyFrom(ProjectRunConfiguration config, bool isRename)
-    {
-      base.OnCopyFrom(config, isRename);
-    }
   }
 }
 

--- a/RhinoRunConfiguration.cs
+++ b/RhinoRunConfiguration.cs
@@ -3,7 +3,7 @@ using MonoDevelop.Ide.Gui.Dialogs;
 using MonoDevelop.Projects;
 
 
-namespace MonoDevelop.Debugger.Soft.Rhino
+namespace MonoDevelop.RhinoDebug
 {
   internal class RhinoRunConfigurationEditor : MonoDevelop.Ide.Projects.OptionPanels.RunConfigurationPanel
   {

--- a/RhinoSoftDebuggerEngine.cs
+++ b/RhinoSoftDebuggerEngine.cs
@@ -1,51 +1,24 @@
 using System;
-
+using MonoDevelop.Core.Execution;
 
 namespace MonoDevelop.Debugger.Soft.Rhino
 {
   public class RhinoSoftDebuggerEngine : SoftDebuggerEngine
   {
-    public string Id { get { return "Mono.Debugger.Soft.Rhino"; } }
+    public string Id => "Mono.Debugger.Soft.Rhino";
 
     public const string DebuggerName = "RhinoCommon Plug-In Debugger";
-    public string Name { get { return DebuggerName; } }
 
-    public override Mono.Debugging.Client.DebuggerStartInfo CreateDebuggerStartInfo(MonoDevelop.Core.Execution.ExecutionCommand cmd)
+    public string Name => DebuggerName;
+
+    public override bool CanDebugCommand(ExecutionCommand cmd)
     {
-      string start_args = String.Empty;
-      string bin_dir = String.Empty;
-      string plugin_path = String.Empty;
-      string rhinocommon_path = String.Empty;
-      bool isGrasshopper = false;
-      var execution_cmd = cmd as RhinoCommonExecutionCommand;
-      if (execution_cmd != null)
-      {
-        start_args = execution_cmd.Arguments;
-        string target = execution_cmd.Command;
-        if (!string.IsNullOrWhiteSpace(target) && System.IO.File.Exists(target))
-        {
-          plugin_path = target;
-          bin_dir = System.IO.Path.GetDirectoryName(target);
-        }
+      return cmd is RhinoExecutionCommand;
+    }
 
-        if (execution_cmd.Project != null)
-        {
-          for (int i = 0; i < execution_cmd.Project.References.Count; i++)
-          {
-            var reference = execution_cmd.Project.References[i];
-            if (reference.HintPath != null && reference.HintPath.FileNameWithoutExtension == "RhinoCommon")
-            {
-              rhinocommon_path = reference.HintPath;
-            }
-            if (reference.HintPath != null && reference.HintPath.FileNameWithoutExtension  == "Grasshopper")
-            {
-              isGrasshopper = true;
-            }
-          }
-        }
-      }
-
-      return new RhinoDebuggerStartInfo("Rhino", start_args, bin_dir, plugin_path, rhinocommon_path, isGrasshopper);
+    public override Mono.Debugging.Client.DebuggerStartInfo CreateDebuggerStartInfo(ExecutionCommand c)
+    {
+      return new RhinoDebuggerStartInfo((RhinoExecutionCommand)c);
     }
 
     public override Mono.Debugging.Client.DebuggerSession CreateSession()

--- a/RhinoSoftDebuggerEngine.cs
+++ b/RhinoSoftDebuggerEngine.cs
@@ -1,7 +1,8 @@
-using System;
+﻿using System;
 using MonoDevelop.Core.Execution;
+using MonoDevelop.Debugger.Soft;
 
-namespace MonoDevelop.Debugger.Soft.Rhino
+namespace MonoDevelop.RhinoDebug
 {
   public class RhinoSoftDebuggerEngine : SoftDebuggerEngine
   {

--- a/RhinoSoftDebuggerSession.cs
+++ b/RhinoSoftDebuggerSession.cs
@@ -35,12 +35,12 @@ namespace MonoDevelop.Debugger.Soft.Rhino
         process_args = process_path.Substring("arch ".Length).Trim();
         process_path = "arch";
       }
-      
+
+      process_args += " " + dsi.Arguments;
+
       MonoDevelop.Core.LoggingService.LogInfo("Starting Rhino for debugging");
-      if (dsi.ContainsCustomStartArgs)
-      {
-        MonoDevelop.Core.LoggingService.LogInfo("--custom start app = " + dsi.ApplicationPath);
-      }
+      MonoDevelop.Core.LoggingService.LogInfo("Start app = " + dsi.ApplicationPath);
+
       var psi = new ProcessStartInfo(process_path);
       psi.UseShellExecute = false;
       psi.RedirectStandardOutput = true;

--- a/RhinoSoftDebuggerSession.cs
+++ b/RhinoSoftDebuggerSession.cs
@@ -1,8 +1,8 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using Mono.Debugging.Soft;
 
-namespace MonoDevelop.Debugger.Soft.Rhino
+namespace MonoDevelop.RhinoDebug
 {
 
   public class RhinoSoftDebuggerSession : SoftDebuggerSession

--- a/Templates/Grasshopper/Component.xpt.xml
+++ b/Templates/Grasshopper/Component.xpt.xml
@@ -1,32 +1,35 @@
 ﻿<?xml version="1.0"?>
 <Template>
-  <TemplateConfiguration>
-    <_Name>Grasshopper Component</_Name>
-    <Category>other/rhino/general</Category>
-    <LanguageName>C#</LanguageName>
-    <_Description>A new Grasshopper Component that can be easily debugged and can automatically launch Rhino.</_Description>
-    <Wizard>MonoDevelop.RhinoDebug.PluginWizard</Wizard>
-    <Image id="grasshopper-project" />
-  </TemplateConfiguration>
-  <Combine name="${ProjectName}" directory=".">
-    <Project name="${ProjectName}" directory="./${ProjectName}">
-      <Options Target="Library" TargetFrameworkVersion="4.5" />
-      <Files>
-        <File name="Properties/AssemblyInfo.cs" AddStandardHeader="True" src="AssemblyInfo.cs" />
-        <FileTemplateReference TemplateID="Grasshopper.EmptyComponent" name="${ProjectName}Component.cs" if="!ProvideCodeSample" />
-        <File name="${ProjectName}Component.cs" AddStandardHeader="True" src="SimpleComponent.cs" if="ProvideCodeSample"  />
-        <File name="${ProjectName}Info.cs" AddStandardHeader="True" src="Info.cs"  />
-      </Files>
-      <References>
-        <Reference type="Gac" refto="System" />
-        <Reference type="Gac" refto="System.Core" />
-        <Reference type="Gac" refto="System.Drawing" />
-        <Reference type="Assembly" refto="/Applications/Rhinoceros.app/Contents/Resources/ManagedPlugIns/GrasshopperPlugin.rhp/Grasshopper.dll" LocalCopy="False" />
-        <Reference type="Assembly" refto="/Applications/Rhinoceros.app/Contents/Resources/ManagedPlugIns/GrasshopperPlugin.rhp/GH_IO.dll" LocalCopy="False" />
-        <Reference type="Assembly" refto="/Applications/Rhinoceros.app/Contents/Resources/RhinoCommon.dll" LocalCopy="False" />
-        <Reference type="Assembly" refto="/Applications/Rhinoceros.app/Contents/Resources/Rhino.UI.dll" LocalCopy="False" />
-        <Reference type="Assembly" refto="/Applications/Rhinoceros.app/Contents/Resources/Eto.dll" LocalCopy="False" />
-      </References>
-    </Project>
-  </Combine>
+    <TemplateConfiguration>
+        <_Name>Grasshopper Component</_Name>
+        <Category>other/rhino/general</Category>
+        <LanguageName>C#</LanguageName>
+        <_Description>A new Grasshopper Component that can be easily debugged and can automatically launch Rhino.</_Description>
+        <Wizard>MonoDevelop.RhinoDebug.PluginWizard</Wizard>
+        <Image id="grasshopper-project" />
+    </TemplateConfiguration>
+    <Combine name="${ProjectName}" directory=".">
+        <Project name="${ProjectName}" directory="./${ProjectName}">
+            <Options Target="Library" TargetFrameworkVersion="4.5" />
+            <Files>
+                <File name="Properties/AssemblyInfo.cs" AddStandardHeader="True" src="AssemblyInfo.cs" />
+                <FileTemplateReference TemplateID="Grasshopper.EmptyComponent" name="${ProjectName}Component.cs" if="!ProvideCodeSample" />
+                <File name="${ProjectName}Component.cs" AddStandardHeader="True" src="SimpleComponent.cs" if="ProvideCodeSample" />
+                <File name="${ProjectName}Info.cs" AddStandardHeader="True" src="Info.cs" />
+            </Files>
+            <References>
+                <Reference type="Gac" refto="System" />
+                <Reference type="Gac" refto="System.Core" />
+                <Reference type="Gac" refto="System.Drawing" />
+                <Reference type="Assembly" refto="/Applications/Rhinoceros.app/Contents/Resources/ManagedPlugIns/GrasshopperPlugin.rhp/Grasshopper.dll" LocalCopy="False" if="!v6" />
+                <Reference type="Assembly" refto="/Applications/Rhinoceros.app/Contents/Resources/ManagedPlugIns/GrasshopperPlugin.rhp/GH_IO.dll" LocalCopy="False" if="!v6" />
+                <Reference type="Assembly" refto="/Applications/Rhinoceros.app/Contents/Resources/RhinoCommon.dll" LocalCopy="False" if="!v6" />
+                <Reference type="Assembly" refto="/Applications/Rhinoceros.app/Contents/Resources/Rhino.UI.dll" LocalCopy="False" if="!v6" />
+                <Reference type="Assembly" refto="/Applications/Rhinoceros.app/Contents/Resources/Eto.dll" LocalCopy="False" if="!v6" />
+            </References>
+            <Packages>
+                <Package ID="Grasshopper" Version="6.12.19029.6381" if="v6" />
+            </Packages>
+        </Project>
+    </Combine>
 </Template>

--- a/Templates/Rhino/Plugin.xpt.xml
+++ b/Templates/Rhino/Plugin.xpt.xml
@@ -1,30 +1,33 @@
 ﻿<?xml version="1.0"?>
 <Template>
-  <TemplateConfiguration>
-    <_Name>RhinoCommon Plug-In</_Name>
-    <Category>other/rhino/general</Category>
-    <LanguageName>C#</LanguageName>
-    <_Description>A new RhinoCommon plug-in that can be easily debugged and can automatically launch Rhino.</_Description>
-    <Wizard>MonoDevelop.RhinoDebug.PluginWizard</Wizard>
-    <Image id="rhinocommon-project" />
-  </TemplateConfiguration>
-  <Combine name="${ProjectName}" directory=".">
-    <Project name="${ProjectName}" directory="./${ProjectName}">
-      <Options Target="Library" TargetFrameworkVersion="4.5" />
-      <Files>
-        <File name="Properties/AssemblyInfo.cs" AddStandardHeader="True" src="AssemblyInfo.cs" />
-        <FileTemplateReference TemplateID="Rhino.EmptyCommand" name="${ProjectName}Command.cs" if="!ProvideCodeSample" />
-        <File name="${ProjectName}Command.cs" AddStandardHeader="True" src="SimpleCommand.cs" if="ProvideCodeSample" />
-        <File name="${ProjectName}Plugin.cs" AddStandardHeader="True" src="Plugin.cs" />
-      </Files>
-      <References>
-        <Reference type="Gac" refto="System" />
-        <Reference type="Gac" refto="System.Core" />
-        <Reference type="Gac" refto="System.Drawing" />
-        <Reference type="Assembly" refto="/Applications/Rhinoceros.app/Contents/Resources/RhinoCommon.dll" LocalCopy="False" />
-        <Reference type="Assembly" refto="/Applications/Rhinoceros.app/Contents/Resources/Rhino.UI.dll" LocalCopy="False" />
-        <Reference type="Assembly" refto="/Applications/Rhinoceros.app/Contents/Resources/Eto.dll" LocalCopy="False" />
-      </References>
-    </Project>
-  </Combine>
+    <TemplateConfiguration>
+        <_Name>RhinoCommon Plug-In</_Name>
+        <Category>other/rhino/general</Category>
+        <LanguageName>C#</LanguageName>
+        <_Description>A new RhinoCommon plug-in that can be easily debugged and can automatically launch Rhino.</_Description>
+        <Wizard>MonoDevelop.RhinoDebug.PluginWizard</Wizard>
+        <Image id="rhinocommon-project" />
+    </TemplateConfiguration>
+    <Combine name="${ProjectName}" directory=".">
+        <Project name="${ProjectName}" directory="./${ProjectName}">
+            <Options Target="Library" TargetFrameworkVersion="4.5" />
+            <Files>
+                <File name="Properties/AssemblyInfo.cs" AddStandardHeader="True" src="AssemblyInfo.cs" />
+                <FileTemplateReference TemplateID="Rhino.EmptyCommand" name="${ProjectName}Command.cs" if="!ProvideCodeSample" />
+                <File name="${ProjectName}Command.cs" AddStandardHeader="True" src="SimpleCommand.cs" if="ProvideCodeSample" />
+                <File name="${ProjectName}Plugin.cs" AddStandardHeader="True" src="Plugin.cs" />
+            </Files>
+            <References>
+                <Reference type="Gac" refto="System" />
+                <Reference type="Gac" refto="System.Core" />
+                <Reference type="Gac" refto="System.Drawing" />
+                <Reference type="Assembly" refto="/Applications/Rhinoceros.app/Contents/Resources/RhinoCommon.dll" LocalCopy="False" if="!v6" />
+                <Reference type="Assembly" refto="/Applications/Rhinoceros.app/Contents/Resources/Rhino.UI.dll" LocalCopy="False" if="!v6" />
+                <Reference type="Assembly" refto="/Applications/Rhinoceros.app/Contents/Resources/Eto.dll" LocalCopy="False" if="!v6" />
+            </References>
+            <Packages>
+                <Package ID="RhinoCommon" Version="6.12.19029.6381" if="v6" />
+            </Packages>
+        </Project>
+    </Combine>
 </Template>

--- a/Wizard/PluginWizard.cs
+++ b/Wizard/PluginWizard.cs
@@ -10,12 +10,14 @@ namespace MonoDevelop.RhinoDebug.Wizard
     public override string Id { get { return "MonoDevelop.RhinoDebug.PluginWizard"; } }
 
     public bool ProvideCodeSample { get; set; } = true;
+    public int RhinoVersion { get; set; } = 5;
 
     public override void ConfigureWizard()
     {
       base.ConfigureWizard();
 
       Parameters["ProvideCodeSample"] = ProvideCodeSample.ToString();
+      Parameters["v" + RhinoVersion] = true.ToString();
 
       // provide some guid's for our templates
       for (int i = 0; i < 10; i++)
@@ -27,6 +29,7 @@ namespace MonoDevelop.RhinoDebug.Wizard
     public override IEnumerable<ProjectConfigurationControl> GetFinalPageControls()
     {
       yield return new ProvideSampleControl(this);
+      yield return new RhinoVersionControl(this);
     }
 
     public override int TotalPages

--- a/Wizard/PluginWizard.cs
+++ b/Wizard/PluginWizard.cs
@@ -7,7 +7,7 @@ namespace MonoDevelop.RhinoDebug.Wizard
 {
   public class PluginWizard : TemplateWizard
   {
-    public override string Id { get { return "MonoDevelop.RhinoDebug.PluginWizard"; } }
+    public override string Id => "MonoDevelop.RhinoDebug.PluginWizard";
 
     public bool ProvideCodeSample { get; set; } = true;
     public int RhinoVersion { get; set; } = 5;
@@ -32,10 +32,7 @@ namespace MonoDevelop.RhinoDebug.Wizard
       yield return new RhinoVersionControl(this);
     }
 
-    public override int TotalPages
-    {
-      get { return 0; }
-    }
+    public override int TotalPages => 0;
 
     public override WizardPage GetPage(int pageNumber)
     {

--- a/Wizard/RhinoVersionControl.cs
+++ b/Wizard/RhinoVersionControl.cs
@@ -1,0 +1,35 @@
+using System;
+using MonoDevelop.Ide.Templates;
+using MonoDevelop.Ide.Projects;
+using System.Collections.Generic;
+
+namespace MonoDevelop.RhinoDebug.Wizard
+{
+  class RhinoVersionControl : ProjectConfigurationControl
+  {
+    readonly PluginWizard wizard;
+
+    public RhinoVersionControl(PluginWizard wizard)
+    {
+      this.wizard = wizard;
+    }
+
+    public override string Label => "Rhino Version:";
+
+    protected override object CreateNativeWidget<T> ()
+    {
+      var box = new Gtk.HBox();
+      var rb5 = new Gtk.RadioButton("v5") { Active = wizard.RhinoVersion == 5 };
+      var rb6 = new Gtk.RadioButton(rb5, "v6 (WIP)") { Active = wizard.RhinoVersion == 6 };
+      rb5.Toggled += (sender, e) => { if (rb5.Active) wizard.RhinoVersion = 5; };
+      rb6.Toggled += (sender, e) => { if (rb6.Active) wizard.RhinoVersion = 6; };
+
+      box.Spacing = 2;
+      box.PackStart(rb5, false, true, 0);
+      box.PackStart(rb6, false, true, 0);
+
+
+      return box;
+    }
+  }
+}

--- a/addin-project.xml
+++ b/addin-project.xml
@@ -3,7 +3,7 @@ Used by the MonoDevelop Add-In Repository
   http://monodevelop.com/Developers/Articles/Publishing_an_Addin
   http://addins.monodevelop.com/Source/AddinProjectHelp?projectId=1
 -->
-<AddinProject appVersion="7.1">
+<AddinProject appVersion="7.7">
 	<Project platforms="Mac">
 		<AddinFile>bin/Release/MonoDevelop.RhinoDebug.dll</AddinFile>
 		<BuildFile>MonoDevelop.RhinoDebug.sln</BuildFile>

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoDevelop.Addins" version="0.4.4" targetFramework="net461" />
+  <package id="MonoDevelop.Addins" version="0.4.7" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
- When referencing v6 RhinoCommon, it will automatically use **/Applications/RhinoWIP.app** (vs. Rhinoceros.app)
- Added new UI to **Project Options > Build > Rhino** to configure the:
  1. Plugin type (automatic, rhino plugin, grasshopper, or library)
  2. Launcher (automatic, Rhinoceros.app, RhinoWIP.app, or custom path)
- Supports `<RhinoPluginType>` and `<RhinoMacLauncher>` .csproj properties which can be set by the above UI
- Can now select **v5** or **v6** when creating a new Rhino Plugin or Grasshopper Component.  
- For new v6 projects, it will use nuget packages instead of hard links to Rhinoceros.app
- Properly renames .pdb to `MyPlugin.rhp.pdb` or `MyComponent.gha.pdb` to enable debugging 3rd party libraries
- Pass **Project Options > Run > Configurations > Default > Arguments** to rhino when launching, e.g. `-nosplash`
- Enable running Rhino without the mono debugger while still registering the plugin.