### PR TITLE
Fixes for other project types

### DIFF
--- a/MonoDevelop.RhinoDebug.csproj
+++ b/MonoDevelop.RhinoDebug.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG</DefineConstants>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>

--- a/Properties/AddinInfo.cs
+++ b/Properties/AddinInfo.cs
@@ -9,7 +9,7 @@ using Mono.Addins;
 // the same stable release of Xamarin Studio.
 [assembly:Addin(
   "RhinoXamarinStudioAddIn",
-	Version = "7.7.4.0"
+	Version = "7.7.4.1"
 )]
 
 // This controls the displayed name in the Xamarin Studio Add-In Manager...

--- a/RhinoDebuggerStartInfo.cs
+++ b/RhinoDebuggerStartInfo.cs
@@ -12,11 +12,6 @@ namespace MonoDevelop.RhinoDebug
       : base(new Mono.Debugging.Soft.SoftDebuggerListenArgs("Rhino", System.Net.IPAddress.Loopback, 0))
     {
       Arguments = cmd.Arguments;
-      PluginPath = cmd.PluginPath;
-      TargetDirectory = cmd.BinDir;
-      RhinoCommonPath = cmd.RhinoCommonPath;
-      IsGrasshopper = cmd.IsGrasshopper;
-      RhinoVersion = cmd.RhinoVersion;
       foreach (var env in cmd.EnvironmentVariables)
       {
         EnvironmentVariables.Add(env.Key, env.Value);
@@ -27,11 +22,6 @@ namespace MonoDevelop.RhinoDebug
 
     public string ApplicationPath { get; private set; }
     public string ExecutablePath { get; private set; }
-    public string TargetDirectory { get; private set; }
-    public string PluginPath { get; private set; }
-    public string RhinoCommonPath { get; private set; }
-    public bool IsGrasshopper { get; private set; }
-    public int RhinoVersion { get; private set; }
   }
 }
 

--- a/RhinoExecutionCommand.cs
+++ b/RhinoExecutionCommand.cs
@@ -13,9 +13,11 @@ namespace MonoDevelop.RhinoDebug
     string _applicationPath;
     string _executablePath;
 
-    public DotNetProject Project { get; set; }
+    public bool ExternalConsole { get; set; }
 
-    public bool IsGrasshopper { get; set; }
+    public bool PauseConsoleOutput { get; set; }
+
+    public DotNetProject Project { get; set; }
 
     public string RhinoCommonPath { get; set; }
 
@@ -25,28 +27,28 @@ namespace MonoDevelop.RhinoDebug
 
     public int RhinoVersion { get; set; }
 
+    public McNeelProjectType RhinoPluginType { get; set; }
+
     public string ApplicationPath => _applicationPath ?? (_applicationPath = GetApplicationPath());
 
     public string ExecutablePath => _executablePath ?? (_executablePath = GetExecutablePath(ApplicationPath));
 
-    public RhinoExecutionCommand(DotNetProject project, string workingDirectory, string outputname, string startArguments, IDictionary<string, string> environmentVariables)
+    public RhinoExecutionCommand(DotNetProject project, McNeelProjectType pluginType, string workingDirectory, string outputname, string startArguments, IDictionary<string, string> environmentVariables)
     {
       Project = project;
       Arguments = startArguments;
       WorkingDirectory = workingDirectory;
       Command = outputname;
       RhinoVersion = project.GetRhinoVersion() ?? Helpers.DefaultRhinoVersion;
+      RhinoPluginType = pluginType;
 
       for (int i = 0; i < Project.References.Count; i++)
       {
+        // old way of finding app by using the path to RhinoCommon.dll
         var reference = Project.References[i];
         if (reference.HintPath != null && reference.HintPath.FileNameWithoutExtension == Helpers.RhinoCommonReferenceName)
         {
           RhinoCommonPath = reference.HintPath;
-        }
-        if (reference.HintPath != null && reference.HintPath.FileNameWithoutExtension == Helpers.GrasshopperReferenceName)
-        {
-          IsGrasshopper = true;
         }
       }
 
@@ -65,9 +67,9 @@ namespace MonoDevelop.RhinoDebug
       }
       if (!string.IsNullOrEmpty(PluginPath))
       {
-        if (IsGrasshopper)
+        if (RhinoPluginType == McNeelProjectType.Grasshopper)
           EnvironmentVariables["GRASSHOPPER_PLUGINS"] = PluginPath;
-        else
+        else if (RhinoPluginType == McNeelProjectType.RhinoCommon)
           EnvironmentVariables["RHINO_PLUGIN_PATH"] = PluginPath;
       }
     }


### PR DESCRIPTION
- Fix broken xamarin.mac and other project types
- Don’t register all projects that they can be executed
- Properly reload project when NuGet package is added/removed
- Use plugin type that is specified for the project when launching rhino
- UI tweaks