### PR TITLE
Make V6 the default version

### DIFF
--- a/Wizard/RhinoVersionControl.cs
+++ b/Wizard/RhinoVersionControl.cs
@@ -19,14 +19,14 @@ namespace MonoDevelop.RhinoDebug.Wizard
     protected override object CreateNativeWidget<T> ()
     {
       var box = new Gtk.HBox();
-      var rb5 = new Gtk.RadioButton("v5") { Active = wizard.RhinoVersion == 5 };
-      var rb6 = new Gtk.RadioButton(rb5, "v6 (WIP)") { Active = wizard.RhinoVersion == 6 };
-      rb5.Toggled += (sender, e) => { if (rb5.Active) wizard.RhinoVersion = 5; };
+      var rb6 = new Gtk.RadioButton("V6") { Active = wizard.RhinoVersion == 6 };
+      var rb5 = new Gtk.RadioButton(rb6, "V5") { Active = wizard.RhinoVersion == 5 };
       rb6.Toggled += (sender, e) => { if (rb6.Active) wizard.RhinoVersion = 6; };
+      rb5.Toggled += (sender, e) => { if (rb5.Active) wizard.RhinoVersion = 5; };
 
       box.Spacing = 2;
-      box.PackStart(rb5, false, true, 0);
       box.PackStart(rb6, false, true, 0);
+      box.PackStart(rb5, false, true, 0);
 
 
       return box;


### PR DESCRIPTION
Reorder the radio buttons making the default version V6 and remove the WIP label in preparation for V6 shipping