### PR TITLE
Fix v5 Compiling and new Command file template

### DIFF
--- a/MonoDevelop.RhinoDebug/Properties/AddinInfo.cs
+++ b/MonoDevelop.RhinoDebug/Properties/AddinInfo.cs
@@ -9,7 +9,7 @@ using Mono.Addins;
 // the same stable release of Xamarin Studio.
 [assembly:Addin(
   "RhinoXamarinStudioAddIn",
-	Version = "8.2.0.4"
+	Version = "8.4.4.0"
 )]
 
 // This controls the displayed name in the Xamarin Studio Add-In Manager...

--- a/MonoDevelop.RhinoDebug/RhinoGlobalProperties.cs
+++ b/MonoDevelop.RhinoDebug/RhinoGlobalProperties.cs
@@ -43,8 +43,9 @@ namespace MonoDevelop.RhinoDebug
       if (!RequiresMdb)
         return s_emptyDictionary;
 
-      // in mono 5.0, it only generates mdb's if using mcs so that means no C#7.
+      // in mono 5.0, it only generates mdb's if using mcs so switch to that compiler
       return properties ?? (properties = new Dictionary<string, string> {
+          { "LangVersion" , "7.2" }, // mcs only supports up to C# v7.2 currently..
           { "CscToolExe" , "mcs.exe" },
           { "_DebugFileExt" , ".mdb" }
         });

--- a/MonoDevelop.RhinoDebug/Templates/Rhino/EmptyCommand.cs
+++ b/MonoDevelop.RhinoDebug/Templates/Rhino/EmptyCommand.cs
@@ -6,12 +6,12 @@ using Rhino.Input;
 using Rhino.Input.Custom;
 using Rhino.UI;
 
-namespace MyRhino
+namespace ${Namespace}
 {
   [System.Runtime.InteropServices.Guid("${Guid2}")]
-  public class MyRhinoCommand : Rhino.Commands.Command
+  public class ${EscapedIdentifier} : Rhino.Commands.Command
   {
-    public MyRhinoCommand()
+    public ${EscapedIdentifier}()
     {
       // Rhino only creates one instance of each command class defined in a
       // plug-in, so it is safe to store a refence in a static property.
@@ -19,9 +19,9 @@ namespace MyRhino
     }
 
     ///<summary>The only instance of this command.</summary>
-    public static MyRhinoCommand Instance { get; private set; }
+    public static ${EscapedIdentifier} Instance { get; private set; }
 
-    public override string EnglishName => "MyRhinoCommand";
+    public override string EnglishName => "${EscapedIdentifier}";
 
     protected override Result RunCommand(Rhino.RhinoDoc doc, RunMode mode)
     {

--- a/Rhino.Templates/templates/Grasshopper/MyGrasshopper.csproj
+++ b/Rhino.Templates/templates/Grasshopper/MyGrasshopper.csproj
@@ -2,7 +2,6 @@
 	
   <PropertyGroup>
     <TargetFramework>net45</TargetFramework>
-    <RootNamespace>MyGrasshopper</RootNamespace>
     <Version>1.0</Version>
     <Title>MyGrasshopper</Title>
     <Description>Description of MyGrasshopper</Description>

--- a/Rhino.Templates/templates/Rhino/MyRhino.csproj
+++ b/Rhino.Templates/templates/Rhino/MyRhino.csproj
@@ -2,7 +2,6 @@
 	
   <PropertyGroup>
     <TargetFramework>net45</TargetFramework>
-    <RootNamespace>MyRhino</RootNamespace>
     <Version>1.0</Version>
     <Title>MyRhino</Title>
     <Description>Description of MyRhino</Description>


### PR DESCRIPTION
- When compiling for v5 we now set the LangVersion to 7.2 so it can compile
- When adding a new Rhino Command to an existing project it now use the name of the file for the class and command name
- Project templates no longer set RootNamespace as it is not needed.